### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ Download Scream from: https://github.com/duncanthrax/scream
 
 Download Scream for the guest: https://github.com/duncanthrax/scream/releases
 
-Supported Linux distributions: Ubuntu, Manjaro, Fedora, PopOS and Mint
+Supported Linux distributions: Ubuntu, Manjaro, Fedora, PopOS, Arch and Mint
 
 For guide, visit: https://youtu.be/AfUgNEOx3uk

--- a/audio.sh
+++ b/audio.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-/usr/bin/scream -i virbr0

--- a/audio.sh.desktop
+++ b/audio.sh.desktop
@@ -1,4 +1,4 @@
 [Desktop Entry]
 Type=Application
-Exec="/usr/bin/scream_audio.sh"
+Exec="/usr/bin/scream-audio"
 X-GNOME-Autostart-enabled=true

--- a/helper.sh
+++ b/helper.sh
@@ -10,12 +10,15 @@ if [ $EUID -ne 0 ]
 		exit 1
 fi
 
-#This script should only run if scream-master is present
-if [ -a scream-master ]
+
+SCREAM_SOURCE=$(find . -maxdepth 1 -type d -iname '*scream*' -print -quit)
+
+#This script should only run if scream source folder is present
+if [ -d "$SCREAM_SOURCE" ]
 	then 
 		echo "Continuing with scream installation"
 	else
-		echo "Scream-master not found in this directory. Please move scream-master into this directory and try again."
+		echo "Scream source folder not found in this directory. Please move scream source folder into this directory and try again."
 		exit
 fi
 
@@ -64,7 +67,7 @@ echo "You can still install Looking Glass manually!"
 fi
 
 #Compiling scream receiver
-cd scream-master/Receivers/unix/
+cd $SCREAM_SOURCE/Receivers/unix/
 
 mkdir build
 

--- a/helper.sh
+++ b/helper.sh
@@ -36,7 +36,12 @@ cp audio.sh.desktop /home/$THE_USER/.config/autostart/
 chown $THE_USER /home/$THE_USER/.config/autostart/audio.sh.desktop
 
 #This will be used to autostart scream and can be edited if different parameters are used
-cp audio.sh /usr/bin/scream_audio.sh
+cp scream-audio /usr/bin/scream-audio
+
+#This will be used to retrieve all bridge devices on this computer, 
+# save them to /etc/scream/devices, 
+# and use found devices for scream later
+cp scream-reconfigure /usr/bin/scream-reconfigure
 
 #Installing required packages
 
@@ -45,15 +50,15 @@ FEDORA=`cat /etc/*release |  head -n 1 | cut -d ' ' -f 1`
 
 if [ "$DISTRO" == "Ubuntu" ] || [ "$DISTRO" == "Pop" ] || [ "$DISTRO" == "LinuxMint" ]
 	then
-apt install libpulse-dev make cmake libasound2-dev -y
-elif [ "$DISTRO" == "ManjaroLinux" ]
+apt install libpulse-dev make cmake screen libasound2-dev  -y
+elif [ "$DISTRO" == "ManjaroLinux" ] || [ "$DISTRO" == "Arch" ]
 	then
-pacman -Syu cmake make base-devel
+pacman -Syu cmake make base-devel screen
 elif [ "$FEDORA" == "Fedora" ]
 	then
-dnf install cmake make gcc pulseaudio-libs-devel alsa-lib-devel libpcap-devel
+dnf install cmake make gcc screen pulseaudio-libs-devel alsa-lib-devel libpcap-devel
 	else
-echo "This script does not support your current distribution. Only Ubuntu, PopOS, Manjaro, and Mint are supported!"
+echo "This script does not support your current distribution. Only Ubuntu, PopOS, Manjaro, Arch and Mint are supported!"
 echo "You can still install Looking Glass manually!"
 	exit
 fi
@@ -72,11 +77,15 @@ make
 #Moving files to their expected locations
 mv scream /usr/bin/scream
 
+#Adding permissions to run copied files
 chmod +x /usr/bin/scream
+chmod +x /usr/bin/scream-audio
+chmod +x /usr/bin/scream-reconfigure
 
-
-chmod +x /usr/bin/scream_audio.sh
-
+#Detecting and saving bridge devices for scream to use.
+#If you want to specify them manually,
+# edit /etc/scream/devices to change list of devices for scream to use
+scream-reconfigure
 
 #In Fedora Scream is normally blocked by the firewall - opening up a port
 if [ "$FEDORA" == "Fedora" ]

--- a/scream-audio
+++ b/scream-audio
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+CONFIG_FILE="/etc/scream/devices"
+
+for device in $(cat $CONFIG_FILE);
+do
+	if ! screen -list | grep "scream-audio-$device"
+	then
+		screen -S "scream-audio-$device" -dm /usr/bin/scream -i $device
+	fi
+done
+

--- a/scream-reconfigure
+++ b/scream-reconfigure
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+CONFIG_FILE="/etc/scream/devices"
+
+if [ $EUID -ne 0 ]
+  then echo "Please run as root"
+  exit
+fi
+
+
+if [ ! -d $(dirname $CONFIG_FILE) ]
+then 
+	echo "No directory found for $CONFIG_FILE, creating..."
+	mkdir $(dirname $CONFIG_FILE)
+else
+	echo "$CONFIG_FILE was found, should the script remove it? y/N"
+	read YN
+	
+	if [ -z $YN ]; then YN=n; fi	
+	if [ $YN = y ]
+	then
+		echo "Removing $CONFIG_FILE. New devices will be added to a new file crated instead of it..."
+		rm $CONFIG_FILE
+	else
+		echo "$CONFIG_FILE will not be removed, new devices will be added to the existing file."
+	fi
+fi
+
+echo ""
+
+for line in `virsh net-list --all --name`
+do
+	device=$(echo $(virsh net-info --network $line | grep "Bridge:") | sed "s/Bridge: //")
+	echo $device >> $CONFIG_FILE
+	echo "Found a bridge device: $device"
+done
+
+echo ""
+echo "Found device names were saved to $CONFIG_FILE. They will now be used by scream."
+echo "If you want to exclude some devices, edit $CONFIG_FILE manually."
+echo "Done."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -15,14 +15,28 @@ if [ -a /usr/bin/scream ]
 fi
 
 
-if [ -a /usr/bin/scream_audio.sh ]
+if [ -a /usr/bin/scream-audio ]
 	then 
-	rm /usr/bin/scream_audio.sh
+	rm /usr/bin/scream-audio
+fi
+
+
+if [ -a /usr/bin/scream-reconfigure ]
+	then 
+	rm /usr/bin/scream-reconfigure
 fi
 
 
 if [ -a /home/$LOGNAME/.config/autostart/audio.sh.desktop ]
 	then 
 	rm /home/$LOGNAME/.config/autostart/audio.sh.desktop
+fi
+
+
+#Ensuring that files from the older versions are removed too
+
+if [ -a /usr/bin/scream_audio.sh ]
+	then 
+	rm /usr/bin/scream_audio.sh
 fi
 


### PR DESCRIPTION
Sometimes multiple vms use different networks, but the script listens to only virbr0. I propose changes that make helper run a script that finds all network bridge devices, and saves them to /etc/scream/devices. Then, when scream-audio is run on startup, it reads this list and launches scream for each bridge device.

The script also detects whether the given bridge device is already used by scream and does not run new instances for this device.

Because of this, if you create any new networks, you can execute scream-reconfigure and then scream-audio from the terminal to run audio for new networks.

if you want to choose which bridge devices to use by yourself, don't run scream-reconfigure, but instead edit /etc/scream/devices to manually list all the needed devices.

I also renamed some files to make them more pleasant to run from the terminal (I think .sh extension is unnecessary - running scream-audio from shell without .sh, just like any command, such as sed, ls or grep, feels natural).

Apart from that, Arch support is enabled just by adding another condition to Manjaro pacman installation.